### PR TITLE
Fix matching end of variable filter expression.

### DIFF
--- a/Django CSS.sublime-syntax
+++ b/Django CSS.sublime-syntax
@@ -106,7 +106,11 @@ contexts:
 
   exprfilter:
     - meta_content_scope: variable.function.filter.django
-    - match: "[ :]"
+    # End the filter expression when we encounter anything that can't be part of the filter name,
+    # typically a space, a colon (e.g. {{var|filter:arg}}), or the closing }}.
+    # We use a look-ahead so that we don't swallow the curly bracket, as if we do then the `expr`
+    # context won't be able to match "}}".
+    - match: "(?=[^\\w])"
       pop: true
 
   commentline:

--- a/Django HTML.sublime-syntax
+++ b/Django HTML.sublime-syntax
@@ -106,7 +106,11 @@ contexts:
 
   exprfilter:
     - meta_content_scope: variable.function.filter.django
-    - match: "[ :]"
+    # End the filter expression when we encounter anything that can't be part of the filter name,
+    # typically a space, a colon (e.g. {{var|filter:arg}}), or the closing }}.
+    # We use a look-ahead so that we don't swallow the curly bracket, as if we do then the `expr`
+    # context won't be able to match "}}".
+    - match: "(?=[^\\w])"
       pop: true
 
   commentline:

--- a/Django XML.sublime-syntax
+++ b/Django XML.sublime-syntax
@@ -106,7 +106,11 @@ contexts:
 
   exprfilter:
     - meta_content_scope: variable.function.filter.django
-    - match: "[ :]"
+    # End the filter expression when we encounter anything that can't be part of the filter name,
+    # typically a space, a colon (e.g. {{var|filter:arg}}), or the closing }}.
+    # We use a look-ahead so that we don't swallow the curly bracket, as if we do then the `expr`
+    # context won't be able to match "}}".
+    - match: "(?=[^\\w])"
       pop: true
 
   commentline:

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ To install for development clone this repo (or symlink it) to `~/.config/sublime
 
 Once symlinked, when editing the syntax definition any loaded files using that definition should update automatically.
 
-Edit only `Django HTML.sublime-syntax` and use `build.py` to generate the `CSS` and `XML` variants.
+Edit only `Django HTML.sublime-syntax` and then run `build.py` to generate the `CSS` and `XML` variants before committing changes.

--- a/syntax_test_django.html.djt
+++ b/syntax_test_django.html.djt
@@ -61,3 +61,8 @@
 <span>{{ current_time|date:"D d M Y"|title }}</span>
                        {# ^^^^^^^^^^^ -variable.function.filter.django #}
                                   {# ^^^^ variable.function.filter.django #}
+
+<span>{{current_time|date}}</span>
+                  {# ^^^^ variable.function.filter.django #}
+   {# ^^ punctuation.section.block.begin #}
+                      {# ^^ punctuation.section.block.end #}


### PR DESCRIPTION
Fixes #4.

Now correctly ends the filter expression if the closing curly braces are encountered but with no space before them.